### PR TITLE
backport upstream fix for noisy loglines at process exit

### DIFF
--- a/kafka/producer/base.py
+++ b/kafka/producer/base.py
@@ -458,5 +458,5 @@ class Producer(object):
         self.stopped = True
 
     def __del__(self):
-        if not self.stopped:
+        if self.async and not self.stopped:
             self.stop()


### PR DESCRIPTION
This is a backport of https://github.com/dpkp/kafka-python/pull/567 to address CACHESERV-48. (Specifically, it's the result of ` git cherry-pick 00d527f480299` into Yelp's master branch.)

The original fix is included in upstream versions 1.0.2 and higher. So if we're planning to upgrade to 1.x soon, we can just wait.