### PR TITLE
Emit metrics via reporters

### DIFF
--- a/kafka/metrics/dict_reporter.py
+++ b/kafka/metrics/dict_reporter.py
@@ -81,3 +81,9 @@ class DictReporter(AbstractMetricsReporter):
 
     def close(self):
         pass
+
+    def record(self, emitter, value):
+        pass
+
+    def get_emitter(self, metric):
+        pass

--- a/kafka/metrics/dict_reporter.py
+++ b/kafka/metrics/dict_reporter.py
@@ -82,7 +82,7 @@ class DictReporter(AbstractMetricsReporter):
     def close(self):
         pass
 
-    def record(self, emitter, value):
+    def record(self, emitter, value, timestamp):
         pass
 
     def get_emitter(self, metric):

--- a/kafka/metrics/metrics.py
+++ b/kafka/metrics/metrics.py
@@ -160,7 +160,6 @@ class Metrics(object):
                 logger.debug('Added sensor with name %s', name)
             return sensor
 
-
     def remove_sensor(self, name):
         """
         Remove a sensor (if it exists), associated metrics and its children.

--- a/kafka/metrics/metrics.py
+++ b/kafka/metrics/metrics.py
@@ -140,11 +140,15 @@ class Metrics(object):
         if sensor:
             return sensor
 
+
         with self._lock:
             sensor = self.get_sensor(name)
             if not sensor:
-                sensor = Sensor(self, name, parents, config or self.config,
-                                inactive_sensor_expiration_time_seconds)
+                sensor = Sensor(
+                    self, name, parents, config or self.config,
+                    inactive_sensor_expiration_time_seconds,
+                    self._reporters
+                )
                 self._sensors[name] = sensor
                 if parents:
                     for parent in parents:
@@ -155,6 +159,7 @@ class Metrics(object):
                         children.append(sensor)
                 logger.debug('Added sensor with name %s', name)
             return sensor
+
 
     def remove_sensor(self, name):
         """

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -58,8 +58,19 @@ class AbstractMetricsReporter(object):
 
     @abc.abstractmethod
     def get_emitter(self, metric):
-        """Called to return an instance of an emitter like meteorite etc"""
+        """
+        Called to return an instance of an emitter like meteorite etc
+        
+        Arguments:
+            metric (str): the name of the metric
+        """
 
     @abc.abstractmethod
     def record(self, emitter, value):
-        """ called to record and emit metrics"""
+        """
+        Called to record and emit metrics
+        
+        Arguments:
+            emitter: reference to an emitter 
+            value(float): value to be emitted
+        """

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -59,18 +59,19 @@ class AbstractMetricsReporter(object):
     @abc.abstractmethod
     def get_emitter(self, metric):
         """
-        Called to return an instance of an emitter like meteorite etc
-        
+        Called to return an instance of an emitter
+
         Arguments:
             metric (str): the name of the metric
         """
 
     @abc.abstractmethod
-    def record(self, emitter, value):
+    def record(self, emitter, value, timestamp):
         """
         Called to record and emit metrics
-        
+
         Arguments:
-            emitter: reference to an emitter 
+            emitter: reference to an emitter
             value(float): value to be emitted
+            timestamp: the time the value was recorded at
         """

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -55,3 +55,11 @@ class AbstractMetricsReporter(object):
     def close(self):
         """Called when the metrics repository is closed."""
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_emitter(self, metric):
+        """Called to return an instance of an emitter like meteorite etc"""
+
+    @abc.abstractmethod
+    def record(self, emitter, value):
+        """ called to record and emit metrics"""

--- a/kafka/metrics/stats/sensor.py
+++ b/kafka/metrics/stats/sensor.py
@@ -30,7 +30,7 @@ class Sensor(object):
             inactive_sensor_expiration_time_seconds * 1000)
         self._last_record_time = time.time() * 1000
         self._check_forest(set())
-        self._emitters = dict( (reporter, reporter.get_emitter(name)) for
+        self._emitters = dict((reporter, reporter.get_emitter(name)) for
                                reporter in reporters )
 
     def _check_forest(self, sensors):

--- a/kafka/metrics/stats/sensor.py
+++ b/kafka/metrics/stats/sensor.py
@@ -16,7 +16,7 @@ class Sensor(object):
     of metrics about request sizes such as the average or max.
     """
     def __init__(self, registry, name, parents, config,
-                 inactive_sensor_expiration_time_seconds):
+                 inactive_sensor_expiration_time_seconds, reporters):
         if not name:
             raise ValueError('name must be non-empty')
         self._lock = threading.RLock()
@@ -30,6 +30,8 @@ class Sensor(object):
             inactive_sensor_expiration_time_seconds * 1000)
         self._last_record_time = time.time() * 1000
         self._check_forest(set())
+        self._emitters = dict( (reporter, reporter.get_emitter(name)) for
+                               reporter in reporters )
 
     def _check_forest(self, sensors):
         """Validate that this sensor doesn't end up referencing itself."""
@@ -64,6 +66,8 @@ class Sensor(object):
             QuotaViolationException: if recording this value moves a
                 metric beyond its configured maximum or minimum bound
         """
+        for reporter, emitter in self._emitters.items():
+            reporter.record(emitter, value)
         if time_ms is None:
             time_ms = time.time() * 1000
         self._last_record_time = time_ms

--- a/kafka/metrics/stats/sensor.py
+++ b/kafka/metrics/stats/sensor.py
@@ -66,10 +66,10 @@ class Sensor(object):
             QuotaViolationException: if recording this value moves a
                 metric beyond its configured maximum or minimum bound
         """
-        for reporter, emitter in self._emitters.items():
-            reporter.record(emitter, value)
         if time_ms is None:
             time_ms = time.time() * 1000
+        for reporter, emitter in self._emitters.items():
+            reporter.record(emitter, value, time_ms)
         self._last_record_time = time_ms
         with self._lock:  # XXX high volume, might be performance issue
             # increment all the stats


### PR DESCRIPTION
This allow metrics to be reported via metric_reporters. This ties a hook into sensors to emit as metrics are being generated. 