### PR TITLE
making a common way to report metrics

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -90,9 +90,7 @@ class SimpleClient(object):
         if host_key not in self._conns:
             metrics = None
             if self.metrics_responder:
-                metrics = Metrics(
-                    reporters=[self.metrics_responder]
-                )
+                metrics = Metrics(reporters=[self.metrics_responder])
             self._conns[host_key] = BrokerConnection(
                 host, port, afi,
                 request_timeout_ms=self.timeout * 1000,

--- a/kafka/metrics/dict_reporter.py
+++ b/kafka/metrics/dict_reporter.py
@@ -85,5 +85,5 @@ class DictReporter(AbstractMetricsReporter):
     def record(self, metric_name, value, timestamp=None):
         pass
 
-    def get_emitter(self, metric_name, prefix='', default_dimensions=None):
+    def get_emitter(self, metric_name):
         pass

--- a/kafka/metrics/dict_reporter.py
+++ b/kafka/metrics/dict_reporter.py
@@ -82,7 +82,7 @@ class DictReporter(AbstractMetricsReporter):
     def close(self):
         pass
 
-    def record(self, emitter, value, timestamp):
+    def record(self, name, value, timestamp):
         pass
 
     def get_emitter(self, metric):

--- a/kafka/metrics/dict_reporter.py
+++ b/kafka/metrics/dict_reporter.py
@@ -82,8 +82,8 @@ class DictReporter(AbstractMetricsReporter):
     def close(self):
         pass
 
-    def record(self, name, value, timestamp):
+    def record(self, metric_name, value, timestamp=None):
         pass
 
-    def get_emitter(self, metric):
+    def get_emitter(self, metric_name, prefix='', default_dimensions=None):
         pass

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -57,21 +57,23 @@ class AbstractMetricsReporter(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_emitter(self, metric):
+    def get_emitter(self, metric_name, prefix='', default_dimensions=None):
         """
         Called to return an instance of an emitter
 
         Arguments:
-            metric (str): the name of the metric
+            metric_name (str): the name of the metric
+            prefix (str): the prefix attached to the metric for reporting
+            default_dimensions: the extra dimensions provided for the metric
         """
 
     @abc.abstractmethod
-    def record(self, name, value, timestamp):
+    def record(self, metric_name, value, timestamp=None):
         """
         Called to record and emit metrics
 
         Arguments:
-            name: name of the metric to be recorded
+            metric_name: name of the metric to be recorded
             value(float): value to be emitted
             timestamp: the time the value was recorded at
         """

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -66,12 +66,12 @@ class AbstractMetricsReporter(object):
         """
 
     @abc.abstractmethod
-    def record(self, emitter, value, timestamp):
+    def record(self, name, value, timestamp):
         """
         Called to record and emit metrics
 
         Arguments:
-            emitter: reference to an emitter
+            name: name of the metric to be recorded
             value(float): value to be emitted
             timestamp: the time the value was recorded at
         """

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -63,8 +63,6 @@ class AbstractMetricsReporter(object):
 
         Arguments:
             metric_name (str): the name of the metric
-            prefix (str): the prefix attached to the metric for reporting
-            default_dimensions: the extra dimensions provided for the metric
         """
 
     @abc.abstractmethod

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -57,7 +57,7 @@ class AbstractMetricsReporter(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_emitter(self, metric_name, prefix='', default_dimensions=None):
+    def get_emitter(self, metric_name):
         """
         Called to return an instance of an emitter
 

--- a/kafka/metrics/stats/sensor.py
+++ b/kafka/metrics/stats/sensor.py
@@ -30,8 +30,7 @@ class Sensor(object):
             inactive_sensor_expiration_time_seconds * 1000)
         self._last_record_time = time.time() * 1000
         self._check_forest(set())
-        self._emitters = dict((reporter, reporter.get_emitter(name)) for
-                               reporter in reporters )
+        self.reporters = reporters
 
     def _check_forest(self, sensors):
         """Validate that this sensor doesn't end up referencing itself."""
@@ -68,8 +67,8 @@ class Sensor(object):
         """
         if time_ms is None:
             time_ms = time.time() * 1000
-        for reporter, emitter in self._emitters.items():
-            reporter.record(emitter, value, time_ms)
+        for reporter in self.reporters:
+            reporter.record(self._name, value, time_ms)
         self._last_record_time = time_ms
         with self._lock:  # XXX high volume, might be performance issue
             # increment all the stats


### PR DESCRIPTION
This pull request takes in changes to report both old and new metrics in a similar way/interface. These changes will be reflected in yelp_kafka more clearly. 

To summarize this change we extend the functionality in AbstractMetricReporter, allowing it have a dict of counters and timers. Since this is a type of metric_reporter, it will be used Metrics and passed on to sensors. Each sensor when collecting and recording data, will call the record method on this, and hence would report metrics.

We pass this in yelp-kafka in the same way as we passed the older metric responder( for reporting older type metics), however with this change the decorator(in kafka_python) will internally call record.

For reporting the new metrics accessible in conn/BrokerConnection, this object will be passed during the creation of the metric class.

Please note, since we are still using the older producer, this implementation is not going to report metrics corresponding to KafkaProducer. A change for that has been earlier added, but those metrics wont be reported while using yelp_kafka

@ny2ko @ecanzonieri this refers to yelp_kafka (r-181824)
