### PR TITLE
Refactor metrics reporter interface

### DIFF
--- a/kafka/metrics/dict_reporter.py
+++ b/kafka/metrics/dict_reporter.py
@@ -82,8 +82,5 @@ class DictReporter(AbstractMetricsReporter):
     def close(self):
         pass
 
-    def record(self, metric_name, value, timestamp=None):
-        pass
-
-    def get_emitter(self, metric_name):
+    def record(self, metric, value, timestamp, config):
         pass

--- a/kafka/metrics/dict_reporter.py
+++ b/kafka/metrics/dict_reporter.py
@@ -82,5 +82,5 @@ class DictReporter(AbstractMetricsReporter):
     def close(self):
         pass
 
-    def record(self, metric, value, timestamp, config):
+    def record(self, sensor_name, metric, value, timestamp, config):
         pass

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -57,11 +57,12 @@ class AbstractMetricsReporter(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def record(self, metric, value, timestamp, config):
+    def record(self, sensor_name, metric, value, timestamp, config):
         """
         Called to record and emit metrics
 
         Arguments:
+            sensor_name: name of the sensor
             metric: KafkaMetric object of the metric to be recorded
             value(float): value to be recorded
             timestamp: the time the value was recorded at

--- a/kafka/metrics/metrics_reporter.py
+++ b/kafka/metrics/metrics_reporter.py
@@ -57,21 +57,13 @@ class AbstractMetricsReporter(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_emitter(self, metric_name):
-        """
-        Called to return an instance of an emitter
-
-        Arguments:
-            metric_name (str): the name of the metric
-        """
-
-    @abc.abstractmethod
-    def record(self, metric_name, value, timestamp=None):
+    def record(self, metric, value, timestamp, config):
         """
         Called to record and emit metrics
 
         Arguments:
-            metric_name: name of the metric to be recorded
-            value(float): value to be emitted
+            metric: KafkaMetric object of the metric to be recorded
+            value(float): value to be recorded
             timestamp: the time the value was recorded at
+            config: sensor config
         """

--- a/kafka/metrics/stats/sensor.py
+++ b/kafka/metrics/stats/sensor.py
@@ -24,7 +24,7 @@ class Sensor(object):
         self._name = name
         self._parents = parents or []
         self._metrics = []
-        self._stats = set()
+        self._stats = []
         self._config = config
         self._inactive_sensor_expiration_time_ms = (
             inactive_sensor_expiration_time_seconds * 1000)
@@ -73,7 +73,7 @@ class Sensor(object):
             for metric in self._metrics:
                 # Some metrics are not stats and they don't have any measurable
                 # we cannot report them.
-                if metric in self._stats:
+                if hasattr(metric, 'measurable'):
                     for reporter in self.reporters:
                         reporter.record(
                             self._name,
@@ -82,7 +82,8 @@ class Sensor(object):
                             time_ms,
                             self._config,
                         )
-                    metric.measurable.record(self._config, value, time_ms)
+            for stat in self._stats:
+                stat.record(self._config, value, time_ms)
             self._check_quotas(time_ms)
         for parent in self._parents:
             parent.record(value, time_ms)
@@ -115,7 +116,7 @@ class Sensor(object):
         """
         if not compound_stat:
             raise ValueError('compound stat must be non-empty')
-        self._stats.add(compound_stat)
+        self._stats.append(compound_stat)
         for named_measurable in compound_stat.stats():
             metric = KafkaMetric(named_measurable.name, named_measurable.stat,
                                  config or self._config)
@@ -136,7 +137,7 @@ class Sensor(object):
             metric = KafkaMetric(metric_name, stat, config or self._config)
             self._registry.register_metric(metric)
             self._metrics.append(metric)
-            self._stats.add(stat)
+            self._stats.append(stat)
 
     def has_expired(self):
         """

--- a/kafka/metrics/stats/sensor.py
+++ b/kafka/metrics/stats/sensor.py
@@ -67,13 +67,13 @@ class Sensor(object):
         """
         if time_ms is None:
             time_ms = time.time() * 1000
-        for reporter in self.reporters:
-            reporter.record(self._name, value, time_ms)
         self._last_record_time = time_ms
         with self._lock:  # XXX high volume, might be performance issue
             # increment all the stats
-            for stat in self._stats:
-                stat.record(self._config, value, time_ms)
+            for metric in self._metrics:
+                metric.measurable.record(self._config, value, time_ms)
+                for reporter in self.reporters:
+                    reporter.record(metric, value, time_ms, self._config)
             self._check_quotas(time_ms)
         for parent in self._parents:
             parent.record(value, time_ms)

--- a/kafka/metrics/stats/sensor.py
+++ b/kafka/metrics/stats/sensor.py
@@ -71,9 +71,10 @@ class Sensor(object):
         with self._lock:  # XXX high volume, might be performance issue
             # increment all the stats
             for metric in self._metrics:
-                metric.measurable.record(self._config, value, time_ms)
+                if hasattr(metric, 'measurable'):
+                    metric.measurable.record(self._config, value, time_ms)
                 for reporter in self.reporters:
-                    reporter.record(metric, value, time_ms, self._config)
+                    reporter.record(self._name, metric, value, time_ms, self._config)
             self._check_quotas(time_ms)
         for parent in self._parents:
             parent.record(value, time_ms)

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.3.2.post2'
+__version__ = '1.3.2.post3'


### PR DESCRIPTION
Remove the get_emitter method and pass the KafkaMetric object to record, that object includes the stat type of the metric.