### PR TITLE
Add support for legacy client and consumer metrics

### DIFF
--- a/kafka/consumer/kafka.py
+++ b/kafka/consumer/kafka.py
@@ -143,7 +143,9 @@ class KafkaConsumer(object):
                 'bootstrap_servers required to configure KafkaConsumer'
             )
 
-        metrics = Metrics(reporters=[self._config['metrics_reporter']()])
+        reporters = [self._config['metrics_reporter']()] if \
+            self._config['metrics_reporter'] else []
+        metrics = Metrics(reporters=reporters)
         self.metrics = KafkaConsumerMetrics(metrics)
 
         self._client = SimpleClient(


### PR DESCRIPTION
I changed the interface of the SimpleClient and legacy KafkaConsumer to make this work.