### PR TITLE
SimpleClient metrics improvements

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -105,6 +105,7 @@ class SimpleClient(object):
                 request_timeout_ms=self.timeout * 1000,
                 client_id=self.client_id,
                 metrics=self._metrics_registry,
+                metric_group_prefix='simple-client',
             )
 
         conn = self._conns[host_key]

--- a/kafka/client.py
+++ b/kafka/client.py
@@ -79,7 +79,7 @@ class SimpleClient(object):
         # We need one connection to bootstrap
         self.client_id = client_id
         self.timeout = timeout
-        self.hosts = collect_hosts(hosts)
+        self.hosts = [host + ('bootstrap',) for host in collect_hosts(hosts)]
         self.correlation_id = correlation_id
         self._metrics_registry = metrics
         self.metrics = SimpleClientMetrics(metrics if metrics else Metrics())
@@ -95,7 +95,7 @@ class SimpleClient(object):
     #   Private API  #
     ##################
 
-    def _get_conn(self, host, port, afi):
+    def _get_conn(self, host, port, afi, node_id='bootstrap'):
         """Get or create a connection to a broker using host and port"""
         host_key = (host, port)
         if host_key not in self._conns:
@@ -106,6 +106,7 @@ class SimpleClient(object):
                 client_id=self.client_id,
                 metrics=self._metrics_registry,
                 metric_group_prefix='simple-client',
+                node_id=node_id,
             )
 
         conn = self._conns[host_key]
@@ -193,17 +194,17 @@ class SimpleClient(object):
         brokers. Keep trying until you succeed.
         """
         hosts = set()
-        for broker in self.brokers.values():
+        for node_id, broker in self.brokers.items():
             host, port, afi = get_ip_port_afi(broker.host)
-            hosts.add((host, broker.port, afi))
+            hosts.add((host, broker.port, afi, node_id))
 
         hosts.update(self.hosts)
         hosts = list(hosts)
         random.shuffle(hosts)
 
-        for (host, port, afi) in hosts:
+        for (host, port, afi, node_id) in hosts:
             try:
-                conn = self._get_conn(host, port, afi)
+                conn = self._get_conn(host, port, afi, node_id)
             except ConnectionError:
                 log.warning("Skipping unconnected connection: %s:%s (AFI %s)",
                             host, port, afi)
@@ -290,7 +291,7 @@ class SimpleClient(object):
 
             host, port, afi = get_ip_port_afi(broker.host)
             try:
-                conn = self._get_conn(host, broker.port, afi)
+                conn = self._get_conn(host, broker.port, afi, broker.nodeId)
             except ConnectionError:
                 refresh_metadata = True
                 failed_payloads(broker_payloads)
@@ -412,7 +413,7 @@ class SimpleClient(object):
 
         host, port, afi = get_ip_port_afi(broker.host)
         try:
-            conn = self._get_conn(host, broker.port, afi)
+            conn = self._get_conn(host, broker.port, afi, broker.nodeId)
         except ConnectionError:
             failed_payloads(payloads)
 

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.3.2.post7'
+__version__ = '1.3.2.post8'

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -36,27 +36,33 @@ class TestSimpleClient(unittest.TestCase):
             client = SimpleClient(hosts=['kafka01:9092', 'kafka02:9092', 'kafka03:9092'])
 
         self.assertEqual(
-            sorted([('kafka01', 9092, socket.AF_UNSPEC), ('kafka02', 9092, socket.AF_UNSPEC),
-                    ('kafka03', 9092, socket.AF_UNSPEC)]),
-            sorted(client.hosts))
+            sorted([('kafka01', 9092, socket.AF_UNSPEC, 'bootstrap'),
+                    ('kafka02', 9092, socket.AF_UNSPEC, 'bootstrap'),
+                    ('kafka03', 9092, socket.AF_UNSPEC, 'bootstrap')]),
+            sorted(client.hosts),
+        )
 
     def test_init_with_csv(self):
         with patch.object(SimpleClient, 'load_metadata_for_topics'):
             client = SimpleClient(hosts='kafka01:9092,kafka02:9092,kafka03:9092')
 
         self.assertEqual(
-            sorted([('kafka01', 9092, socket.AF_UNSPEC), ('kafka02', 9092, socket.AF_UNSPEC),
-                    ('kafka03', 9092, socket.AF_UNSPEC)]),
-            sorted(client.hosts))
+            sorted([('kafka01', 9092, socket.AF_UNSPEC, 'bootstrap'),
+                    ('kafka02', 9092, socket.AF_UNSPEC, 'bootstrap'),
+                    ('kafka03', 9092, socket.AF_UNSPEC, 'bootstrap')]),
+            sorted(client.hosts),
+        )
 
     def test_init_with_unicode_csv(self):
         with patch.object(SimpleClient, 'load_metadata_for_topics'):
             client = SimpleClient(hosts=u'kafka01:9092,kafka02:9092,kafka03:9092')
 
         self.assertEqual(
-            sorted([('kafka01', 9092, socket.AF_UNSPEC), ('kafka02', 9092, socket.AF_UNSPEC),
-                    ('kafka03', 9092, socket.AF_UNSPEC)]),
-            sorted(client.hosts))
+            sorted([('kafka01', 9092, socket.AF_UNSPEC, 'bootstrap'),
+                    ('kafka02', 9092, socket.AF_UNSPEC, 'bootstrap'),
+                    ('kafka03', 9092, socket.AF_UNSPEC, 'bootstrap')]),
+            sorted(client.hosts),
+        )
 
     @patch.object(SimpleClient, '_get_conn')
     @patch.object(SimpleClient, 'load_metadata_for_topics')
@@ -68,7 +74,7 @@ class TestSimpleClient(unittest.TestCase):
         for val in mocked_conns.values():
             mock_conn(val, success=False)
 
-        def mock_get_conn(host, port, afi):
+        def mock_get_conn(host, port, afi, node_id='bootstrap'):
             return mocked_conns[(host, port)]
         conn.side_effect = mock_get_conn
 
@@ -96,7 +102,7 @@ class TestSimpleClient(unittest.TestCase):
         mocked_conns[('kafka02', 9092)].send.return_value = future
         mocked_conns[('kafka02', 9092)].recv.side_effect = lambda: future.success('valid response')
 
-        def mock_get_conn(host, port, afi):
+        def mock_get_conn(host, port, afi, node_id='bootstrap'):
             return mocked_conns[(host, port)]
 
         # patch to avoid making requests before we want it


### PR DESCRIPTION
Fix the metrics group name when creating the BrokerConnection from SimpleClient and pass the node id to be used in BrokerConnection metrics.