### PR TITLE
Send client poll request on every consumer poll request

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -599,7 +599,7 @@ class KafkaConsumer(six.Iterator):
                 self._fetcher.send_fetches()
 
             # To handle any heartbeat responses
-            self._client.poll(timeout_ms=1)
+            self._client.poll(timeout_ms=0)
             return records
 
         # Send any new fetches (won't resend pending fetches)

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -597,7 +597,9 @@ class KafkaConsumer(six.Iterator):
             # fetched records.
             if not partial:
                 self._fetcher.send_fetches()
-            self._client.poll(timeout_ms=timeout_ms)
+
+            # To handle any heartbeat responses
+            self._client.poll(timeout_ms=1)
             return records
 
         # Send any new fetches (won't resend pending fetches)

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -597,6 +597,7 @@ class KafkaConsumer(six.Iterator):
             # fetched records.
             if not partial:
                 self._fetcher.send_fetches()
+            self._client.poll(timeout_ms=timeout_ms)
             return records
 
         # Send any new fetches (won't resend pending fetches)


### PR DESCRIPTION
Currently, the consumer poll returns the records if it has any prefetched records. This leads to missing any heartbeat requests. The consumer poll should send client poll requests on each call.