### PR TITLE
Revert client poll fix inside consumer poll

### DIFF
--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -598,8 +598,6 @@ class KafkaConsumer(six.Iterator):
             if not partial:
                 self._fetcher.send_fetches()
 
-            # To handle any heartbeat responses
-            self._client.poll(timeout_ms=0)
             return records
 
         # Send any new fetches (won't resend pending fetches)


### PR DESCRIPTION
Reverting the fix with [poll](https://github.com/Yelp/kafka-python/pull/39), as it can have severe side-effects like message-loss as explained [here](https://github.com/dpkp/kafka-python/pull/1235#discussion_r142842871). In case the auto-commit set to true, the commits can happen before the records are returned which could lead to message loss on failure.
The correct solution is to send heartbeats in the background thread as handled as part of [KIP-62](https://github.com/dpkp/kafka-python/issues/948).
