### PR TITLE
Upper bound pin on setuptools since we're still testing with py2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ tox==3.1.2
 pylint==1.8.2
 pytest-pylint==0.11.0
 pytest-mock==1.10.0
+setuptools<45.0.0
 sphinx-rtd-theme==0.2.4
 mock==2.0.0
 decorator==4.3.0


### PR DESCRIPTION
I hope this works? I wasn't able to reproduce the error we saw on jenkins locally lol, but the error was just that its using a non-py2 compatible setuptools with py2