### PR TITLE
Fix control batch bug

### DIFF
--- a/kafka/consumer/fetcher.py
+++ b/kafka/consumer/fetcher.py
@@ -821,11 +821,12 @@ class Fetcher(six.Iterator):
                               " offset %d to buffered record list", tp,
                               position)
                     unpacked = list(self._unpack_message_set(tp, records))
-                    parsed_records = self.PartitionRecords(fetch_offset, tp, unpacked)
-                    last_offset = unpacked[-1].offset
-                    self._sensors.records_fetch_lag.record(highwater - last_offset)
-                    num_bytes = records.valid_bytes()
-                    records_count = len(unpacked)
+                    if unpacked:
+                        parsed_records = self.PartitionRecords(fetch_offset, tp, unpacked)
+                        last_offset = unpacked[-1].offset
+                        self._sensors.records_fetch_lag.record(highwater - last_offset)
+                        num_bytes = records.valid_bytes()
+                        records_count = len(unpacked)
                 elif records.size_in_bytes() > 0:
                     # we did not read a single message from a non-empty
                     # buffer because that message's size is larger than

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.4.7.post3'
+__version__ = '1.4.7.post4'


### PR DESCRIPTION
### Problem

`_unpack_message_set` was modified in #72 to skip over transactional control batches. 

Because of this, `unpacked = _unpack_message_set` may return an empty list. 
However, later in the code we reference the last element of that list, `unpacked[-1]`, to find how many messages have been consumed. This causes a `list index out of range` exception

### Solution

To solve this, we do not want to reference `unpacked[-1]`, but skip the message.

### Testing

I have manually edited the file to this from within the `venv` and this error was fixed:
```
{...}/venv/lib/python3.10/site-packages/kafka/consumer/fetcher.py", line 830, in _parse_fetched_data
    last_offset = unpacked[-1].offset
IndexError: list index out of range
exception 'IndexError('list index out of range')' encountered running paastorm.{..}`
```