### PR TITLE
Support MSK IAM Authentication

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -76,7 +76,7 @@ class SimpleClient(object):
     # socket timeout.
     def __init__(self, hosts, client_id=CLIENT_ID,
                  timeout=DEFAULT_SOCKET_TIMEOUT_SECONDS,
-                 correlation_id=0, metrics=None):
+                 correlation_id=0, metrics=None, **kwargs):
         # We need one connection to bootstrap
         self.client_id = client_id
         self.timeout = timeout
@@ -89,6 +89,10 @@ class SimpleClient(object):
         self.brokers = {}            # broker_id -> BrokerMetadata
         self.topics_to_brokers = {}  # TopicPartition -> BrokerMetadata
         self.topic_partitions = {}   # topic -> partition -> leader
+
+        # Support arbitrary kwargs to be provided as config to BrokerConnection
+        # This will allow advanced features like Authentication to work
+        self.config = kwargs
 
         self.load_metadata_for_topics()  # bootstrap with all metadata
 
@@ -108,6 +112,7 @@ class SimpleClient(object):
                 metrics=self._metrics_registry,
                 metric_group_prefix='simple-client',
                 node_id=node_id,
+                **self.config,
             )
 
         conn = self._conns[host_key]

--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -25,6 +25,7 @@ from kafka.vendor import six
 import kafka.errors as Errors
 from kafka.future import Future
 from kafka.metrics.stats import Avg, Count, Max, Rate
+from kafka.msk import AwsMskIamClient
 from kafka.oauth.abstract import AbstractTokenProvider
 from kafka.protocol.admin import SaslHandShakeRequest
 from kafka.protocol.commit import OffsetFetchRequest
@@ -81,6 +82,12 @@ except ImportError:
     gssapi = None
     GSSError = None
 
+# needed for AWS_MSK_IAM authentication:
+try:
+    from botocore.session import Session as BotoSession
+except ImportError:
+    # no botocore available, will disable AWS_MSK_IAM mechanism
+    BotoSession = None
 
 AFI_NAMES = {
     socket.AF_UNSPEC: "unspecified",
@@ -224,7 +231,7 @@ class BrokerConnection(object):
         'sasl_oauth_token_provider': None
     }
     SECURITY_PROTOCOLS = ('PLAINTEXT', 'SSL', 'SASL_PLAINTEXT', 'SASL_SSL')
-    SASL_MECHANISMS = ('PLAIN', 'GSSAPI', 'OAUTHBEARER')
+    SASL_MECHANISMS = ('PLAIN', 'GSSAPI', 'OAUTHBEARER', 'AWS_MSK_IAM')
 
     def __init__(self, host, port, afi, **configs):
         self.host = host
@@ -269,6 +276,11 @@ class BrokerConnection(object):
                 token_provider = self.config['sasl_oauth_token_provider']
                 assert token_provider is not None, 'sasl_oauth_token_provider required for OAUTHBEARER sasl'
                 assert callable(getattr(token_provider, "token", None)), 'sasl_oauth_token_provider must implement method #token()'
+
+            if self.config['sasl_mechanism'] == 'AWS_MSK_IAM':
+                assert BotoSession is not None, 'AWS_MSK_IAM requires the "botocore" package'
+                assert self.config['security_protocol'] == 'SASL_SSL', 'AWS_MSK_IAM requires SASL_SSL'
+
         # This is not a general lock / this class is not generally thread-safe yet
         # However, to avoid pushing responsibility for maintaining
         # per-connection locks to the upstream client, we will use this lock to
@@ -552,6 +564,8 @@ class BrokerConnection(object):
             return self._try_authenticate_gssapi(future)
         elif self.config['sasl_mechanism'] == 'OAUTHBEARER':
             return self._try_authenticate_oauth(future)
+        elif self.config['sasl_mechanism'] == 'AWS_MSK_IAM':
+            return self._try_authenticate_aws_msk_iam(future)
         else:
             return future.failure(
                 Errors.UnsupportedSaslMechanismError(
@@ -650,6 +664,40 @@ class BrokerConnection(object):
             return future.failure(error)
 
         log.info('%s: Authenticated as %s via PLAIN', self, self.config['sasl_plain_username'])
+        return future.success(True)
+
+    def _try_authenticate_aws_msk_iam(self, future):
+        session = BotoSession()
+        client = AwsMskIamClient(
+            host=self.host,
+            boto_session=session,
+        )
+
+        msg = client.first_message()
+        size = Int32.encode(len(msg))
+
+        err = None
+        close = False
+        with self._lock:
+            if not self._can_send_recv():
+                err = Errors.NodeNotReadyError(str(self))
+                close = False
+            else:
+                try:
+                    self._send_bytes_blocking(size + msg)
+                    data = self._recv_bytes_blocking(4)
+                    data = self._recv_bytes_blocking(struct.unpack('4B', data)[-1])
+                except (ConnectionError, TimeoutError) as e:
+                    log.exception("%s: Error receiving reply from server", self)
+                    err = Errors.KafkaConnectionError("%s: %s" % (self, e))
+                    close = True
+
+        if err is not None:
+            if close:
+                self.close(error=err)
+            return future.failure(err)
+
+        log.info('%s: Authenticated via AWS_MSK_IAM %s', self, data.decode('utf-8'))
         return future.success(True)
 
     def _try_authenticate_gssapi(self, future):

--- a/kafka/msk.py
+++ b/kafka/msk.py
@@ -4,6 +4,7 @@ import hmac
 import json
 import string
 
+from kafka.errors import IllegalArgumentError
 from kafka.vendor.six.moves import urllib
 
 
@@ -67,7 +68,7 @@ class AwsMskIamClient:
             return region
 
         # Otherwise give up
-        raise Exception('Could not determine region from broker host(s) or aws configuration')
+        raise IllegalArgumentError('Could not determine region from broker host(s) or aws configuration')
 
     @property
     def _credential(self):

--- a/kafka/msk.py
+++ b/kafka/msk.py
@@ -34,6 +34,11 @@ class AwsMskIamClient:
         self.host = host
         self.boto_session = boto_session
 
+        # This will raise if the region can't be determined
+        # Do this during init instead of waiting for failures downstream
+        if self.region:
+            pass
+
     @property
     def access_key(self):
         return self.boto_session.get_credentials().access_key
@@ -48,11 +53,21 @@ class AwsMskIamClient:
 
     @property
     def region(self):
-        # TODO: This logic is not perfect and should be revisited
+        # Try to get the region information from the broker hostname
         for host in self.host.split(','):
             if 'amazonaws.com' in host:
                 return host.split('.')[-3]
-        return 'us-west-2'
+
+        # If the region can't be determined from hostname, try the boto session
+        # This will only have a value if:
+        #  - `AWS_DEFAULT_REGION` environment variable is set
+        #  - `~/.aws/config` region variable is set
+        region = self.boto_session.get_config_variable('region')
+        if region:
+            return region
+
+        # Otherwise give up
+        raise Exception('Could not determine region from broker host(s) or aws configuration')
 
     @property
     def _credential(self):

--- a/kafka/msk.py
+++ b/kafka/msk.py
@@ -1,0 +1,197 @@
+import datetime
+import hashlib
+import hmac
+import json
+import string
+
+from kafka.vendor.six.moves import urllib
+
+
+class AwsMskIamClient:
+    UNRESERVED_CHARS = string.ascii_letters + string.digits + '-._~'
+
+    def __init__(self, host, boto_session):
+        """
+        Arguments:
+            host (str): The hostname of the broker.
+            boto_session (botocore.BotoSession) the boto session
+        """
+        self.algorithm = 'AWS4-HMAC-SHA256'
+        self.expires = '900'
+        self.hashfunc = hashlib.sha256
+        self.headers = [
+            ('host', host)
+        ]
+        self.version = '2020_10_22'
+
+        self.service = 'kafka-cluster'
+        self.action = '{}:Connect'.format(self.service)
+
+        now = datetime.datetime.utcnow()
+        self.datestamp = now.strftime('%Y%m%d')
+        self.timestamp = now.strftime('%Y%m%dT%H%M%SZ')
+
+        self.host = host
+        self.boto_session = boto_session
+
+    @property
+    def access_key(self):
+        return self.boto_session.get_credentials().access_key
+
+    @property
+    def secret_key(self):
+        return self.boto_session.get_credentials().secret_key
+
+    @property
+    def token(self):
+        return self.boto_session.get_credentials().token
+
+    @property
+    def region(self):
+        # TODO: This logic is not perfect and should be revisited
+        for host in self.host.split(','):
+            if 'amazonaws.com' in host:
+                return host.split('.')[-3]
+        return 'us-west-2'
+
+    @property
+    def _credential(self):
+        return '{0.access_key}/{0._scope}'.format(self)
+
+    @property
+    def _scope(self):
+        return '{0.datestamp}/{0.region}/{0.service}/aws4_request'.format(self)
+
+    @property
+    def _signed_headers(self):
+        """
+        Returns (str):
+            An alphabetically sorted, semicolon-delimited list of lowercase
+            request header names.
+        """
+        return ';'.join(sorted(k.lower() for k, _ in self.headers))
+
+    @property
+    def _canonical_headers(self):
+        """
+        Returns (str):
+            A newline-delited list of header names and values.
+            Header names are lowercased.
+        """
+        return '\n'.join(map(':'.join, self.headers)) + '\n'
+
+    @property
+    def _canonical_request(self):
+        """
+        Returns (str):
+            An AWS Signature Version 4 canonical request in the format:
+                <Method>\n
+                <Path>\n
+                <CanonicalQueryString>\n
+                <CanonicalHeaders>\n
+                <SignedHeaders>\n
+                <HashedPayload>
+        """
+        # The hashed_payload is always an empty string for MSK.
+        hashed_payload = self.hashfunc(b'').hexdigest()
+        return '\n'.join((
+            'GET',
+            '/',
+            self._canonical_querystring,
+            self._canonical_headers,
+            self._signed_headers,
+            hashed_payload,
+        ))
+
+    @property
+    def _canonical_querystring(self):
+        """
+        Returns (str):
+            A '&'-separated list of URI-encoded key/value pairs.
+        """
+        params = []
+        params.append(('Action', self.action))
+        params.append(('X-Amz-Algorithm', self.algorithm))
+        params.append(('X-Amz-Credential', self._credential))
+        params.append(('X-Amz-Date', self.timestamp))
+        params.append(('X-Amz-Expires', self.expires))
+        if self.token:
+            params.append(('X-Amz-Security-Token', self.token))
+        params.append(('X-Amz-SignedHeaders', self._signed_headers))
+
+        return '&'.join(self._uriencode(k) + '=' + self._uriencode(v) for k, v in params)
+
+    @property
+    def _signing_key(self):
+        """
+        Returns (bytes):
+            An AWS Signature V4 signing key generated from the secret_key, date,
+            region, service, and request type.
+        """
+        key = self._hmac(('AWS4' + self.secret_key).encode('utf-8'), self.datestamp)
+        key = self._hmac(key, self.region)
+        key = self._hmac(key, self.service)
+        key = self._hmac(key, 'aws4_request')
+        return key
+
+    @property
+    def _signing_str(self):
+        """
+        Returns (str):
+            A string used to sign the AWS Signature V4 payload in the format:
+                <Algorithm>\n
+                <Timestamp>\n
+                <Scope>\n
+                <CanonicalRequestHash>
+        """
+        canonical_request_hash = self.hashfunc(self._canonical_request.encode('utf-8')).hexdigest()
+        return '\n'.join((self.algorithm, self.timestamp, self._scope, canonical_request_hash))
+
+    def _uriencode(self, msg):
+        """
+        Arguments:
+            msg (str): A string to URI-encode.
+
+        Returns (str):
+            The URI-encoded version of the provided msg, following the encoding
+            rules specified: https://github.com/aws/aws-msk-iam-auth#uriencode
+        """
+        return urllib.parse.quote(msg, safe=self.UNRESERVED_CHARS)
+
+    def _hmac(self, key, msg):
+        """
+        Arguments:
+            key (bytes): A key to use for the HMAC digest.
+            msg (str): A value to include in the HMAC digest.
+        Returns (bytes):
+            An HMAC digest of the given key and msg.
+        """
+        return hmac.new(key, msg.encode('utf-8'), digestmod=self.hashfunc).digest()
+
+    def first_message(self):
+        """
+        Returns (bytes):
+            An encoded JSON authentication payload that can be sent to the
+            broker.
+        """
+        signature = hmac.new(
+            self._signing_key,
+            self._signing_str.encode('utf-8'),
+            digestmod=self.hashfunc,
+        ).hexdigest()
+        msg = {
+            'version':  self.version,
+            'host': self.host,
+            'user-agent': 'kafka-python',
+            'action': self.action,
+            'x-amz-algorithm': self.algorithm,
+            'x-amz-credential': self._credential,
+            'x-amz-date': self.timestamp,
+            'x-amz-signedheaders': self._signed_headers,
+            'x-amz-expires': self.expires,
+            'x-amz-signature': signature,
+        }
+        if self.token:
+            msg['x-amz-security-token'] = self.token
+
+        return json.dumps(msg, separators=(',', ':')).encode('utf-8')

--- a/kafka/version.py
+++ b/kafka/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.4.7.post4'
+__version__ = '1.4.7.post5'

--- a/test/test_msk.py
+++ b/test/test_msk.py
@@ -1,0 +1,67 @@
+import datetime
+import json
+
+from kafka.msk import AwsMskIamClient
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+def client_factory(token=None):
+    now = datetime.datetime.utcfromtimestamp(1629321911)
+    with mock.patch('kafka.msk.datetime') as mock_dt:
+        mock_dt.datetime.utcnow = mock.Mock(return_value=now)
+        return AwsMskIamClient(
+            host='localhost',
+            access_key='XXXXXXXXXXXXXXXXXXXX',
+            secret_key='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+            region='us-east-1',
+            token=token,
+        )
+
+
+def test_aws_msk_iam_client_permanent_credentials():
+    client = client_factory(token=None)
+    msg = client.first_message()
+    assert msg
+    assert isinstance(msg, bytes)
+    actual = json.loads(msg)
+
+    expected = {
+        'version': '2020_10_22',
+        'host': 'localhost',
+        'user-agent': 'kafka-python',
+        'action': 'kafka-cluster:Connect',
+        'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+        'x-amz-credential': 'XXXXXXXXXXXXXXXXXXXX/20210818/us-east-1/kafka-cluster/aws4_request',
+        'x-amz-date': '20210818T212511Z',
+        'x-amz-signedheaders': 'host',
+        'x-amz-expires': '900',
+        'x-amz-signature': '0fa42ae3d5693777942a7a4028b564f0b372bafa2f71c1a19ad60680e6cb994b',
+    }
+    assert actual == expected
+
+
+def test_aws_msk_iam_client_temporary_credentials():
+    client = client_factory(token='XXXXX')
+    msg = client.first_message()
+    assert msg
+    assert isinstance(msg, bytes)
+    actual = json.loads(msg)
+
+    expected = {
+        'version': '2020_10_22',
+        'host': 'localhost',
+        'user-agent': 'kafka-python',
+        'action': 'kafka-cluster:Connect',
+        'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+        'x-amz-credential': 'XXXXXXXXXXXXXXXXXXXX/20210818/us-east-1/kafka-cluster/aws4_request',
+        'x-amz-date': '20210818T212511Z',
+        'x-amz-signedheaders': 'host',
+        'x-amz-expires': '900',
+        'x-amz-signature': 'b0619c50b7ecb4a7f6f92bd5f733770df5710e97b25146f97015c0b1db783b05',
+        'x-amz-security-token': 'XXXXX',
+    }
+    assert actual == expected

--- a/test/test_msk.py
+++ b/test/test_msk.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 from unittest import TestCase
 
+from kafka.errors import IllegalArgumentError
 from kafka.msk import AwsMskIamClient
 
 try:
@@ -81,13 +82,13 @@ def test_aws_msk_iam_no_region(boto_session):
     # No region from config
     boto_session.get_config_variable = mock.MagicMock(return_value=None)
 
-    with TestCase().assertRaises(Exception) as e:
+    with TestCase().assertRaises(IllegalArgumentError) as e:
         # No region from hostname
         msk_client = AwsMskIamClient(
             host='localhost',
             boto_session = boto_session,
         )
-    assert 'Could not determine region from broker host(s) or aws configuration' == str(e.exception)
+    assert 'IllegalArgumentError: Could not determine region from broker host(s) or aws configuration' == str(e.exception)
 
 
 @pytest.mark.parametrize('session_token', [(None), ('the_token')])

--- a/test/test_msk.py
+++ b/test/test_msk.py
@@ -13,21 +13,24 @@ except ImportError:
     import mock
 
 
-@pytest.fixture(params=[{'session_token': 'session_token', 'host': 'localhost'}, {'session_token': None, 'host': 'localhost.us-east-1.amazonaws.com'}])
-def msk_client(request):
+@pytest.fixture
+def boto_session():
     # To avoid a package dependency on the optional botocore library, we mock the module out
     sys.modules['botocore.session'] = mock.MagicMock()
     from botocore.session import Session  # pylint: disable=import-error
 
-    session = Session()
-    session.get_credentials = mock.MagicMock(return_value=mock.MagicMock(id='the_actual_credentials', access_key='akia', secret_key='secret', token=request.param['session_token']))
-    yield AwsMskIamClient(
-        host=request.param["host"],
-        boto_session = session,
+    boto_session = Session()
+    boto_session.get_credentials = mock.MagicMock(return_value=mock.MagicMock(id='the_actual_credentials', access_key='akia', secret_key='secret', token=None))
+    yield boto_session
+
+
+def test_aws_msk_iam_region_from_config(boto_session):
+    # Region determined by configuration
+    boto_session.get_config_variable = mock.MagicMock(return_value='us-west-2')
+    msk_client = AwsMskIamClient(
+        host='localhost',
+        boto_session = boto_session,
     )
-
-
-def test_aws_msk_iam(msk_client):
     msg = msk_client.first_message()
     assert msg
     assert isinstance(msg, bytes)
@@ -39,12 +42,80 @@ def test_aws_msk_iam(msk_client):
         'user-agent': 'kafka-python',
         'action': 'kafka-cluster:Connect',
         'x-amz-algorithm': 'AWS4-HMAC-SHA256',
-        'x-amz-credential': '{}/{}/{}/kafka-cluster/aws4_request'.format(msk_client.access_key, datetime.datetime.utcnow().strftime('%Y%m%d'), 'us-west-2' if msk_client.host == 'localhost' else 'us-east-1'),
+        'x-amz-credential': '{}/{}/us-west-2/kafka-cluster/aws4_request'.format(msk_client.access_key, datetime.datetime.utcnow().strftime('%Y%m%d')),
         'x-amz-date': mock.ANY,
         'x-amz-signedheaders': 'host',
         'x-amz-expires': '900',
         'x-amz-signature': mock.ANY,
     }
-    if msk_client.token:
-        expected['x-amz-security-token'] = msk_client.token
+    TestCase().assertEqual(actual, expected)
+
+
+def test_aws_msk_iam_region_from_hostname(boto_session):
+    # Region determined by hostname
+    msk_client = AwsMskIamClient(
+        host='localhost.us-east-1.amazonaws.com',
+        boto_session = boto_session,
+    )
+    msg = msk_client.first_message()
+    assert msg
+    assert isinstance(msg, bytes)
+    actual = json.loads(msg.decode('utf-8'))
+
+    expected = {
+        'version': '2020_10_22',
+        'host': msk_client.host,
+        'user-agent': 'kafka-python',
+        'action': 'kafka-cluster:Connect',
+        'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+        'x-amz-credential': '{}/{}/us-east-1/kafka-cluster/aws4_request'.format(msk_client.access_key, datetime.datetime.utcnow().strftime('%Y%m%d')),
+        'x-amz-date': mock.ANY,
+        'x-amz-signedheaders': 'host',
+        'x-amz-expires': '900',
+        'x-amz-signature': mock.ANY,
+    }
+    TestCase().assertEqual(actual, expected)
+
+
+def test_aws_msk_iam_no_region(boto_session):
+    # No region from config
+    boto_session.get_config_variable = mock.MagicMock(return_value=None)
+
+    with TestCase().assertRaises(Exception) as e:
+        # No region from hostname
+        msk_client = AwsMskIamClient(
+            host='localhost',
+            boto_session = boto_session,
+        )
+    assert 'Could not determine region from broker host(s) or aws configuration' == str(e.exception)
+
+
+@pytest.mark.parametrize('session_token', [(None), ('the_token')])
+def test_aws_msk_iam_permanent_and_temporary_credentials(session_token, request):
+    boto_session = request.getfixturevalue('boto_session')
+    if session_token:
+        boto_session.get_credentials.return_value.token = session_token
+    msk_client = AwsMskIamClient(
+        host='localhost.us-east-1.amazonaws.com',
+        boto_session = boto_session,
+    )
+    msg = msk_client.first_message()
+    assert msg
+    assert isinstance(msg, bytes)
+    actual = json.loads(msg.decode('utf-8'))
+
+    expected = {
+        'version': '2020_10_22',
+        'host': msk_client.host,
+        'user-agent': 'kafka-python',
+        'action': 'kafka-cluster:Connect',
+        'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+        'x-amz-credential': '{}/{}/us-east-1/kafka-cluster/aws4_request'.format(msk_client.access_key, datetime.datetime.utcnow().strftime('%Y%m%d')),
+        'x-amz-date': mock.ANY,
+        'x-amz-signedheaders': 'host',
+        'x-amz-expires': '900',
+        'x-amz-signature': mock.ANY,
+    }
+    if session_token:
+        expected['x-amz-security-token'] = session_token
     TestCase().assertEqual(actual, expected)

--- a/test/test_msk.py
+++ b/test/test_msk.py
@@ -1,5 +1,9 @@
 import datetime
 import json
+import sys
+
+import pytest
+from unittest import TestCase
 
 from kafka.msk import AwsMskIamClient
 
@@ -9,59 +13,38 @@ except ImportError:
     import mock
 
 
-def client_factory(token=None):
-    now = datetime.datetime.utcfromtimestamp(1629321911)
-    with mock.patch('kafka.msk.datetime') as mock_dt:
-        mock_dt.datetime.utcnow = mock.Mock(return_value=now)
-        return AwsMskIamClient(
-            host='localhost',
-            access_key='XXXXXXXXXXXXXXXXXXXX',
-            secret_key='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-            region='us-east-1',
-            token=token,
-        )
+@pytest.fixture(params=[{'session_token': 'session_token', 'host': 'localhost'}, {'session_token': None, 'host': 'localhost.us-east-1.amazonaws.com'}])
+def msk_client(request):
+    # To avoid a package dependency on the optional botocore library, we mock the module out
+    sys.modules['botocore.session'] = mock.MagicMock()
+    from botocore.session import Session  # pylint: disable=import-error
+
+    session = Session()
+    session.get_credentials = mock.MagicMock(return_value=mock.MagicMock(id='the_actual_credentials', access_key='akia', secret_key='secret', token=request.param['session_token']))
+    yield AwsMskIamClient(
+        host=request.param["host"],
+        boto_session = session,
+    )
 
 
-def test_aws_msk_iam_client_permanent_credentials():
-    client = client_factory(token=None)
-    msg = client.first_message()
+def test_aws_msk_iam(msk_client):
+    msg = msk_client.first_message()
     assert msg
     assert isinstance(msg, bytes)
-    actual = json.loads(msg)
+    actual = json.loads(msg.decode('utf-8'))
 
     expected = {
         'version': '2020_10_22',
-        'host': 'localhost',
+        'host': msk_client.host,
         'user-agent': 'kafka-python',
         'action': 'kafka-cluster:Connect',
         'x-amz-algorithm': 'AWS4-HMAC-SHA256',
-        'x-amz-credential': 'XXXXXXXXXXXXXXXXXXXX/20210818/us-east-1/kafka-cluster/aws4_request',
-        'x-amz-date': '20210818T212511Z',
+        'x-amz-credential': '{}/{}/{}/kafka-cluster/aws4_request'.format(msk_client.access_key, datetime.datetime.utcnow().strftime('%Y%m%d'), 'us-west-2' if msk_client.host == 'localhost' else 'us-east-1'),
+        'x-amz-date': mock.ANY,
         'x-amz-signedheaders': 'host',
         'x-amz-expires': '900',
-        'x-amz-signature': '0fa42ae3d5693777942a7a4028b564f0b372bafa2f71c1a19ad60680e6cb994b',
+        'x-amz-signature': mock.ANY,
     }
-    assert actual == expected
-
-
-def test_aws_msk_iam_client_temporary_credentials():
-    client = client_factory(token='XXXXX')
-    msg = client.first_message()
-    assert msg
-    assert isinstance(msg, bytes)
-    actual = json.loads(msg)
-
-    expected = {
-        'version': '2020_10_22',
-        'host': 'localhost',
-        'user-agent': 'kafka-python',
-        'action': 'kafka-cluster:Connect',
-        'x-amz-algorithm': 'AWS4-HMAC-SHA256',
-        'x-amz-credential': 'XXXXXXXXXXXXXXXXXXXX/20210818/us-east-1/kafka-cluster/aws4_request',
-        'x-amz-date': '20210818T212511Z',
-        'x-amz-signedheaders': 'host',
-        'x-amz-expires': '900',
-        'x-amz-signature': 'b0619c50b7ecb4a7f6f92bd5f733770df5710e97b25146f97015c0b1db783b05',
-        'x-amz-security-token': 'XXXXX',
-    }
-    assert actual == expected
+    if msk_client.token:
+        expected['x-amz-security-token'] = msk_client.token
+    TestCase().assertEqual(actual, expected)


### PR DESCRIPTION
## Feature or Description
Roughly adapted from [this upstream PR](https://github.com/dpkp/kafka-python/pull/2255) that was never merged. 

Changes from that PR:
- Dynamically determine region based on the broker endpoint. The above PR was relying on `AWS_DEFAULT_REGION` which may not always be set
- Always call `boto_session.get_credentials()` to ensure that role credentials that can be automatically refreshed once they expire (from e.g. instance profile, container pod identity, boto profile that do role assumption, etc) will be automatically refreshed
- Support passing down arbitrary kafka configuration properties through `SimpleClient` so fields like `security_protocol` and   `sasl_mechanism` can be passed through to the `BrokerConnection`

## Caveats
- If authentication is not set up correctly, the current behavior is that a `kafka.errors.NoBrokersAvailable: NoBrokersAvailable` error is raised. Basically the failures to authenticate don't bubble up correctly and it just gets treated as if all brokers timed out or otherwise couldn't be connected. I think this can probably be fixed, but my initial attempt to fix it with minimal changes to the overall control flow was unsuccessful
- 

## Testing Done

### KafkaProducer and KafkaConsumer

Producer
```
$ python
Python 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from kafka import KafkaProducer
>>> producer = KafkaProducer(bootstrap_servers="b-3.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-1.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-2.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098", security_protocol="SASL_SSL", sasl_mechanism="AWS_MSK_IAM")
>>> producer.send('dpopes-iam-1', b'test message from Yelp/kafka-python')
<kafka.producer.future.FutureRecordMetadata object at 0x7f792f022680>
>>> producer.send('dpopes-iam-1', b'test message from Yelp/kafka-python')
<kafka.producer.future.FutureRecordMetadata object at 0x7f792f068a30>
```

Consumer
```
$ python
Python 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from kafka import KafkaConsumer
>>> consumer = KafkaConsumer('dpopes-iam-1', bootstrap_servers="b-2.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-3.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-1.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098", security_protocol="SASL_SSL", sasl_mechanism="AWS_MSK_IAM")
>>> for message in consumer:
...  print(message)
...
ConsumerRecord(topic='dpopes-iam-1', partition=0, offset=282, timestamp=1698977783799, timestamp_type=0, key=None, value=b'test message from Yelp/kafka-python', headers=[], checksum=None, serialized_key_size=-1, serialized_value_size=35, serialized_header_size=-1)
ConsumerRecord(topic='dpopes-iam-1', partition=0, offset=283, timestamp=1698977788359, timestamp_type=0, key=None, value=b'test message from Yelp/kafka-python', headers=[], checksum=None, serialized_key_size=-1, serialized_value_size=35, serialized_header_size=-1)
```

### SimpleClient Producer and Consumer

Producer
```
$ python
Python 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from kafka.client import SimpleClient
>>> client = SimpleClient(hosts="b-3.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-1.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-2.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098", security_protocol="SASL_SSL", sasl_mechanism="AWS_MSK_IAM", api_version=None)
>>> from kafka.structs import ProduceRequestPayload
>>> import kafka.protocol.message
>>> client.send_produce_request([ProduceRequestPayload("dpopes-iam-1", 0, [kafka.protocol.message.Message(b"a")])])
[ProduceResponsePayload(topic='dpopes-iam-1', partition=0, error=0, offset=284)]
>>> client.send_produce_request([ProduceRequestPayload("dpopes-iam-1", 0, [kafka.protocol.message.Message(b"b")])])
[ProduceResponsePayload(topic='dpopes-iam-1', partition=0, error=0, offset=285)]
```

Consumer
```
$ python
Python 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from kafka.client import SimpleClient
>>> client = SimpleClient(hosts="b-3.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-1.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-2.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098", security_protocol="SASL_SSL", sasl_mechanism="AWS_MSK_IAM", api_version=None)
>>> from kafka.structs import FetchRequestPayload
>>> client.send_fetch_request([FetchRequestPayload("dpopes-iam-1", 0, 284, 1024)])
[FetchResponsePayload(topic='dpopes-iam-1', partition=0, error=0, highwaterMark=286, messages=[OffsetAndMessage(offset=284, message=Message(crc=1373583922, magic=0, attributes=0, timestamp=None, key=None, value=b'a')), OffsetAndMessage(offset=285, message=Message(crc=-925471864, magic=0, attributes=0, timestamp=None, key=None, value=b'b')), OffsetAndMessage(offset=None, message=PartialMessage(b''))])]
>>> client.send_fetch_request([FetchRequestPayload("dpopes-iam-1", 0, 285, 1024)])
[FetchResponsePayload(topic='dpopes-iam-1', partition=0, error=0, highwaterMark=286, messages=[OffsetAndMessage(offset=285, message=Message(crc=-925471864, magic=0, attributes=0, timestamp=None, key=None, value=b'b')), OffsetAndMessage(offset=None, message=PartialMessage(b''))])]
```

## Admin Client with KafkaClient

### Create Topic

```
$ python
Python 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from kafka.client_async import KafkaClient
>>> from kafka.admin_client import AdminClient
>>> kafka_client = KafkaClient(bootstrap_servers="b-3.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-1.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098,b-2.mycluster.8tc123.c5.kafka.us-west-2.amazonaws.com:9098", security_protocol="SASL_SSL", sasl_mechanism="AWS_MSK_IAM")
>>> admin_client = AdminClient(kafka_client)
>>> admin_client.create_topics([NewTopic("dpopes-iam-3", 1, 1)], 100)
[CreateTopicsResponse_v0(topic_errors=[(topic='dpopes-iam-3', error_code=0)])]
```